### PR TITLE
`nlives: {}` vs `nlives: null` resuming issue

### DIFF
--- a/cobaya/samplers/polychord/polychord.yaml
+++ b/cobaya/samplers/polychord/polychord.yaml
@@ -47,7 +47,7 @@ synchronous : True
 # between loglike contours and nlive.
 # You should still set nlive to be a sensible number, as this indicates
 # how often to update the clustering, and to define the default value.
-nlives : {}
+nlives :
 # Perform maximisation at the end of the run to find the maximum
 # likelihood point and value
 maximise : False


### PR DESCRIPTION
@slegner and I have found that resuming runs which do not get past the timing stage does not work, with the following error:
```
[output] Output to be read-from/written-into folder 'runs/baoaniso', with prefix 'baoaniso'
[output] Found existing info files with the requested output prefix: 'runs/baoaniso/baoaniso'
[output] Let's try to resume/load.
[input] is_equal_info: different content of [sampler:polychord] -- (re-run with `debug: True` for more info)
[sampler] *ERROR* Old and new Sampler information not compatible! Resuming not possible!
[exception handler] ---------------------------------------

 Traceback (most recent call last):
    File "/rds/user/ano23/hpc-work/sinah_test/run_sinah_test.py", line 11, in <module>
       cobaya.run(
    File "/home/ano23/cobaya/cobaya/run.py", line 123, in run
       check_sampler_info(
    File "/home/ano23/cobaya/cobaya/sampler.py", line 120, in check_sampler_info
      raise LoggedError(
cobaya.log.LoggedError: Old and new Sampler information not compatible! Resuming not possible!
-------------------------------------------------------------
```

switching to `debug=True`

```
 2023-08-02 16:46:09,138 [output] Output to be read-from/written-into folder 'runs/baoaniso', with prefix 'baoaniso'
 2023-08-02 16:46:09,139 [output] Found existing info files with the requested output prefix: 'runs/baoaniso/baoaniso'
 2023-08-02 16:46:09,139 [output] Let's try to resume/load.
 2023-08-02 16:46:09,388 [input] Parameter 'A_planck' is multiply defined but consistent.
 2023-08-02 16:46:09,659 [input] is_equal_info: different content of [sampler:polychord] -- (re-run with `debug: True` for more info)
 2023-08-02 16:46:09,659 [input] {'nlives': {}} (old) vs {'nlives': None} (new)
 2023-08-02 16:46:09,659 [sampler] *ERROR* Old and new Sampler information not compatible! Resuming not possible!
```

Looking at the `.updated.yaml` file at different stages of the setup, it appears that before the blocking is calculated, `nlives: {}`, and switches to `nlives: null` afterwards. (sorry @williamjameshandley for the screenshot)
![Screenshot 2023-08-02 at 16 47 17](https://github.com/handley-lab/cobaya/assets/52655393/1bd49cfb-e30a-4db1-b8ab-c7e07d1fe65b)

Changing polychord.nlives default to null (i.e. blank) seems to have fixed this